### PR TITLE
Directly run &shell when opening a new terminal

### DIFF
--- a/autoload/nvim_toggle_terminal.vim
+++ b/autoload/nvim_toggle_terminal.vim
@@ -47,7 +47,7 @@ function! nvim_toggle_terminal#Toggle(terminal_ref) abort
     let w:alternate_buffer = exists("w:alternate_buffer") ? w:alternate_buffer : @#
 
     keepjumps enew
-    call termopen(&shell, {a:terminal_ref})
+    call termopen([&shell], {a:terminal_ref})
     set bufhidden=hide
     set nobuflisted
     let {a:terminal_ref}.loaded = v:true


### PR DESCRIPTION
I have a prompt that show me the level of nested shells.
This is accomplished by taking the value of the environment variable `$SHLVL`
which is incremented at every new shell opened.

I noticed that when I used `:terminal` to open a terminal, the `$SHLVL` was 2
but when I used `:ToggleTerminal`, the `$SHLVL` was 3.

So I search and found the `termopen()` call with `&shell` instead of `[&shell]` which was
responsible of spawning bash in bash.